### PR TITLE
set python executable var to custom cmake commands

### DIFF
--- a/rosidl_generator_rs/cmake/custom_command.cmake
+++ b/rosidl_generator_rs/cmake/custom_command.cmake
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+
 add_custom_command(
   OUTPUT
   ${_generated_common_rs_files}


### PR DESCRIPTION
Fixes #2. 

The variable PYTHON_EXECUTABLE wasn't set so just the python file was executed, which works on ubuntu but not on windows. On windows, there needs to be `python python_script`