### PR TITLE
build!: require Rust 2024 edition

### DIFF
--- a/rosidl_generator_rs/resource/Cargo.toml.em
+++ b/rosidl_generator_rs/resource/Cargo.toml.em
@@ -1,7 +1,7 @@
 [package]
 name = "@(package_name)"
 version = "@(package_version)"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 rosidl_runtime_rs = "0.5"

--- a/rosidl_generator_rs/resource/action.rs.em
+++ b/rosidl_generator_rs/resource/action.rs.em
@@ -81,7 +81,7 @@ type_name = action_spec.namespaced_type.name
 }@
 
 #[link(name = "@(package_name)__rosidl_typesupport_c")]
-extern "C" {
+unsafe extern "C" {
     fn rosidl_typesupport_c__get_action_type_support_handle__@(package_name)__@(subfolder)__@(type_name)() -> *const std::ffi::c_void;
 }
 

--- a/rosidl_generator_rs/resource/msg_rmw.rs.em
+++ b/rosidl_generator_rs/resource/msg_rmw.rs.em
@@ -16,12 +16,12 @@ type_name = msg_spec.structure.namespaced_type.name
 }@
 
 #[link(name = "@(package_name)__rosidl_typesupport_c")]
-extern "C" {
+unsafe extern "C" {
     fn rosidl_typesupport_c__get_message_type_support_handle__@(package_name)__@(subfolder)__@(type_name)() -> *const std::ffi::c_void;
 }
 
 #[link(name = "@(package_name)__rosidl_generator_c")]
-extern "C" {
+unsafe extern "C" {
     fn @(package_name)__@(subfolder)__@(type_name)__init(msg: *mut @(type_name)) -> bool;
     fn @(package_name)__@(subfolder)__@(type_name)__Sequence__init(seq: *mut rosidl_runtime_rs::Sequence<@(type_name)>, size: usize) -> bool;
     fn @(package_name)__@(subfolder)__@(type_name)__Sequence__fini(seq: *mut rosidl_runtime_rs::Sequence<@(type_name)>);

--- a/rosidl_generator_rs/resource/srv_idiomatic.rs.em
+++ b/rosidl_generator_rs/resource/srv_idiomatic.rs.em
@@ -24,7 +24,7 @@ type_name = srv_spec.namespaced_type.name
 }@
 
 #[link(name = "@(package_name)__rosidl_typesupport_c")]
-extern "C" {
+unsafe extern "C" {
     fn rosidl_typesupport_c__get_service_type_support_handle__@(package_name)__@(subfolder)__@(type_name)() -> *const std::ffi::c_void;
 }
 


### PR DESCRIPTION
This PR updates the generated message packages to the Rust 2024 edition.