### PR TITLE
Change the package metadata to point to the new `ros-env` crate

### DIFF
--- a/rosidl_generator_rs/resource/Cargo.toml.em
+++ b/rosidl_generator_rs/resource/Cargo.toml.em
@@ -21,5 +21,5 @@ for dep in dependency_packages:
 }@
 serde = @(serde_features)
 
-[package.metadata.rclrs]
-reexport = true
+[package.metadata.ros-env]
+include = true


### PR DESCRIPTION
As per discussions in https://github.com/ros2-rust/ros2_rust/pull/556, it would be ideal to move the "re-exporting" of generated rust message crates to a new crate external of `rclrs`.

Just need to change the generated metadata fields to reflect this.