### PR TITLE
fix(rosidl_generator_rs_generate_interfaces): Remove poisoning of global CMAKE_SHARED_LINKER_FLAGS variable

### DIFF
--- a/rosidl_generator_rs/cmake/rosidl_generator_rs_generate_interfaces.cmake
+++ b/rosidl_generator_rs/cmake/rosidl_generator_rs_generate_interfaces.cmake
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(NOT WIN32)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
-  elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
-  endif()
-endif()
-
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_rs/${PROJECT_NAME}")
 set(_generated_common_rs_files "")


### PR DESCRIPTION
I could not find why those lines were there in the first place (they were there since the first version of the repo)  but in general `CMAKE_*` variables are global variables that have a global effect, so unless there is a clear specific motivation, it is better to avoid modifying their value, as it could create side-effects in unrelated part of the CMake project in which this is used, see for example https://github.com/ros2/rosidl_python/pull/253 .