### PR TITLE
perf(generator): use memcpy paths for primitive sequence conversion

### DIFF
--- a/rosidl_generator_rs/resource/templates/msg_idiomatic.rs.em
+++ b/rosidl_generator_rs/resource/templates/msg_idiomatic.rs.em
@@ -139,8 +139,12 @@ impl rosidl_runtime_rs::Message for @(type_name) {
           .into_iter()
           .map(|elem| @(get_rs_type(member.type.value_type))::into_rmw_message(std::borrow::Cow::Owned(elem)).into_owned())
           .collect(),
+@# Owned BasicType sequences: borrow the slice and route through
+@# From<&[T]> for Sequence<T> so the copy compiles to a memcpy via
+@# clone_from_slice's Copy specialization, instead of From<Vec<T>>'s
+@# per-element extend path. See ros2-rust/ros2_rust#628.
 @[        else]@
-        @(get_rs_name(member.name)): msg.@(get_rs_name(member.name)).into(),
+        @(get_rs_name(member.name)): msg.@(get_rs_name(member.name)).as_slice().into(),
 @[        end if]@
 @#
 @#
@@ -243,14 +247,26 @@ impl rosidl_runtime_rs::Message for @(type_name) {
 @#
 @#    == UnboundedSequence ==
 @[    elif isinstance(member.type, UnboundedSequence)]@
+@# Primitive sequences use the From<Sequence<T>> for Vec<T> impl (memcpy via
+@# as_slice().to_vec()), avoiding O(n) per-element read/zero-write that the
+@# SequenceIterator path performs. See ros2-rust/ros2_rust#628.
+@[        if isinstance(member.type.value_type, BasicType)]@
+      @(get_rs_name(member.name)): msg.@(get_rs_name(member.name)).into(),
+@[        elif isinstance(member.type.value_type, UnboundedString) or isinstance(member.type.value_type, UnboundedWString)]@
       @(get_rs_name(member.name)): msg.@(get_rs_name(member.name))
           .into_iter()
-@[        if isinstance(member.type.value_type, UnboundedString) or isinstance(member.type.value_type, UnboundedWString)]@
           .map(|elem| elem.to_string())
-@[        elif isinstance(member.type.value_type, NamedType) or isinstance(member.type.value_type, NamespacedType)]@
-          .map(@(get_rs_type(member.type.value_type))::from_rmw_message)
-@[        end if]@
           .collect(),
+@[        elif isinstance(member.type.value_type, NamedType) or isinstance(member.type.value_type, NamespacedType)]@
+      @(get_rs_name(member.name)): msg.@(get_rs_name(member.name))
+          .into_iter()
+          .map(@(get_rs_type(member.type.value_type))::from_rmw_message)
+          .collect(),
+@[        else]@
+      @(get_rs_name(member.name)): msg.@(get_rs_name(member.name))
+          .into_iter()
+          .collect(),
+@[        end if]@
 @#
 @#
 @#    == UnboundedString + UnboundedWString ==


### PR DESCRIPTION
This is the second of a set of 2 PRs that address issue number 2 described in ros2-rust/ros2_rust#628

https://github.com/ros2-rust/rosidl_runtime_rs/pull/20 has to be merged first.

## Problem
### 2. Element-by-element sequence conversion in `from_rmw_message`

The generated `from_rmw_message` code converts `Sequence<T>` to `Vec<T>` via `.into_iter().collect()`. The `SequenceIterator::next()` implementation (`rosidl_runtime_rs/src/sequence.rs`) does this **per element**:

```rust
let elem = ptr.read();
ptr.write(std::mem::zeroed::<T>());  // writes zero back for EVERY element
```

For a 64 KB `Sequence<u8>`, this is 65,536 individual read + zero-write + insert cycles instead of a single `memcpy`.

## Solution

Generated `from_rmw_message` and `into_rmw_message` impls for `UnboundedSequence<BasicType>` fields now route through `memcpy`-based conversion paths instead of per-element iteration / writes.

- **Receive side (`from_rmw_message`)** — emits `msg.field.into()`, which routes through `From<Sequence<T>> for Vec<T>` (added in [`ros2-rust/rosidl_runtime_rs#20`](https://github.com/ros2-rust/rosidl_runtime_rs/pull/20)) → `as_slice().to_vec()` → `memcpy`. Replaces `into_iter().collect()`, which paid a per-element read+zero-write via `SequenceIterator::next()`.
- **Publish side (`into_rmw_message`, Owned arm)** — emits `msg.field.as_slice().into()`, which routes through the existing `From<&[T]> for Sequence<T>` → `Sequence::new + clone_from_slice` → `memcpy` (via stdlib's `Copy` specialization on `clone_from_slice`). Replaces `msg.field.into()`, which routed through `From<Vec<T>> for Sequence<T>` → `extend`, paying a per-element write through bounds-checked `IndexMut`.

The Borrowed arm of `into_rmw_message` already used `msg.field.as_slice().into()` and is unchanged. Non-primitive sequence branches (`String`, `WString`, nested `Message`-typed sequences) are unchanged — they need real per-element conversion.

**Depends on:** [`ros2-rust/rosidl_runtime_rs#20`](https://github.com/ros2-rust/rosidl_runtime_rs/pull/20)) for the new `From<Sequence<T>> for Vec<T>` impl. That PR must be released first before this PR's generated code will compile against a published `rosidl_runtime_rs`.

## Benchmarks

For benchmarks, see [`ros2-rust/rosidl_runtime_rs#20`](https://github.com/ros2-rust/rosidl_runtime_rs/pull/20))