### PR TITLE
ci: build Debian packages on main

### DIFF
--- a/.github/workflows/build-deb.yaml
+++ b/.github/workflows/build-deb.yaml
@@ -1,0 +1,62 @@
+name: Build Debian packages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  build-deb:
+    name: Build Debian packages (${{ matrix.rosdistro }} / ${{ matrix.debdistro }})
+    runs-on: ubuntu-24.04
+    if: github.repository_owner == 'ros2-rust'
+    concurrency:
+      group: build-deb-${{ github.ref }}-${{ matrix.rosdistro }}-${{ matrix.debdistro }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rosdistro: lyrical
+            debdistro: resolute
+          - rosdistro: rolling
+            debdistro: resolute
+          - rosdistro: kilted
+            debdistro: noble
+          - rosdistro: jazzy
+            debdistro: noble
+          - rosdistro: humble
+            debdistro: jammy
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: repo
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create repos file for this commit
+        working-directory: repo
+        run: |
+          cat > sources.repos <<EOF
+          repositories:
+            rosidl_rust:
+              type: git
+              url: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git
+              version: ${GITHUB_SHA}
+          EOF
+
+      - name: Build Debian packages
+        uses: esteve/ros-deb-builder-action@tier4/main
+        with:
+          ROS_DISTRO: ${{ matrix.rosdistro }}
+          DEB_DISTRO: ${{ matrix.debdistro }}
+          REPOS_FILE: sources.repos
+          SKIP_CHECKOUT: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGES_BRANCH: ${{ matrix.debdistro }}-${{ matrix.rosdistro }}
+          DEBIAN_REVISION_PREFIX: 0~
+          SQUASH_HISTORY: true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
 # rosidl_rust
- rosidl support for Rust
+
+rosidl support for Rust
+
+## Debian packages
+
+The Debian package build workflow publishes apt repositories to package branches
+named `<ubuntu-codename>-<ros-distro>`.
+
+| ROS distribution | Ubuntu distribution | Package branch |
+| --- | --- | --- |
+| Rolling | Resolute | `resolute-rolling` |
+| Lyrical | Resolute | `resolute-lyrical` |
+| Kilted | Noble | `noble-kilted` |
+| Jazzy | Noble | `noble-jazzy` |
+| Humble | Jammy | `jammy-humble` |
+
+To install the generated packages, choose the matching package branch for your
+ROS and Ubuntu distribution:
+
+```bash
+export ROS_DISTRO=rolling
+export PACKAGE_BRANCH=resolute-rolling
+
+echo "deb [trusted=yes] https://raw.githubusercontent.com/ros2-rust/rosidl_rust/${PACKAGE_BRANCH}/ ./" \
+  | sudo tee "/etc/apt/sources.list.d/ros2-rust-rosidl-rust-${PACKAGE_BRANCH}.list"
+
+echo "yaml https://raw.githubusercontent.com/ros2-rust/rosidl_rust/${PACKAGE_BRANCH}/local.yaml ${ROS_DISTRO}" \
+  | sudo tee "/etc/ros/rosdep/sources.list.d/1-ros2-rust-rosidl-rust-${PACKAGE_BRANCH}.list"
+
+sudo apt update
+rosdep update
+sudo apt install "ros-${ROS_DISTRO}-rosidl-generator-rs"
+```
+
+Replace `ROS_DISTRO` and `PACKAGE_BRANCH` with the matching values from the
+table above.
+
+Generated package versions use the nearest reachable tag, the number of commits
+since that tag, the commit date in UTC, and the short commit SHA. For example,
+a package built from tag `0.4.13` sorts below the official ROS buildfarm release:
+
+```text
+0.4.13-0~2026.06.14.22.00+gabcdef123456
+```
+
+A package built from a newer commit after that tag sorts above the older tagged
+release while remaining deterministic for rebuilds of the same commit:
+
+```text
+0.4.13+git1-0~2026.06.15.09.30+g123456abcdef
+```


### PR DESCRIPTION
This PR builds Debian packages and stores them in a Git branch so that users can install more recent versions of the generator before the packages hit the ROS buildfarm.